### PR TITLE
[#1] Changed addressing mode in .get_byte

### DIFF
--- a/SAM2600.a
+++ b/SAM2600.a
@@ -432,7 +432,7 @@ vox_task
 ;	50..7F -> pause of 1..48 vbl frames
 
 .get_byte
-        lda	(VOX_PTR),x
+        lda	(VOX_PTR,x)
         beq	.1
         inc	VOX_PTR
         bne	.0


### PR DESCRIPTION
LDA (VOX_PTR),x isn't a valid instruction according to my version of
DASM (2.20.13), so it won't compile.

Changing this line to LDA (VOX_PTR,x) generates code that is identical
to the example code in SAM2600.rom, so I can assume it to be correct.