### PR TITLE
Remove requirement for xmacro.h

### DIFF
--- a/SAM2600.a
+++ b/SAM2600.a
@@ -1,7 +1,6 @@
 	processor 6502
         include "vcs.h"
         include "macro.h"
-        include "xmacro.h"
 
 ;=============================================================
 ; SAM2600
@@ -282,7 +281,9 @@ vox_task
         jmp	.linez		; no phase change, proceed to blend
         
 .phase_change
-	TIMER_SETUP 7		; start in v:-37
+	lda	#7	; start in v:-37
+	sta	WSYNC
+	sta	TIM64T
 
 	lda	VOX_FLAGS
         lda	#VOX_FLAG_MIXING


### PR DESCRIPTION
The include file `xmacro.h` is only required for to use the
`TIMER_SETUP` macro once, which only contains a few instructions.
My copy of DASM didn't come with `xmacro.h`, and the version I found
online generated slightly different code from the included sample ROM.
Therefore it makes some sense to just spell out the code, and remove
the include file.